### PR TITLE
(fix) updated the GUI for changing whether a goal is repeatable

### DIFF
--- a/src/main/java/me/thegabro/playtimemanager/GUIs/Goals/GoalSettingsGui.java
+++ b/src/main/java/me/thegabro/playtimemanager/GUIs/Goals/GoalSettingsGui.java
@@ -140,7 +140,7 @@ public class GoalSettingsGui implements InventoryHolder, Listener {
         inventory.setItem(Slots.GOAL_REPEATABLE_STATUS, createGuiItem(
                 goal.isRepeatable() ? Material.LIME_DYE : Material.GRAY_DYE,
                 Component.text(goal.isRepeatable() ? "§a§lGoal repeatable" : "§c§lGoal not repeatable"),
-                Component.text("§7Click to make this goal " + (goal.isActive() ? "not " : "") + "repeatable")
+                Component.text("§7Click to make this goal " + (goal.isRepeatable() ? "not " : "") + "repeatable")
         ));
 
         inventory.setItem(Slots.GOAL_OFFLINE_REWARDS, createGuiItem(


### PR DESCRIPTION
The "Click to make this goal [not/] repeatable" GUI option now properly displays "not" when the goal is repeatable, rather than when it's active